### PR TITLE
fix: shorten variable names to avoid code block overflow (#204)

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -511,10 +511,10 @@ Możesz użyć dyrektywy `@vue-generic`, aby przekazać typy, gdy typ nie może 
 ```vue
 <template>
   <!-- @vue-generic {import('@/api').Actor} -->
-  <ApiSelect v-model="selectedPeopleIds" endpoint="/api/actors" id-prop="actorId" />
+  <ApiSelect v-model="peopleIds" endpoint="/api/actors" id-prop="actorId" />
 
   <!-- @vue-generic {import('@/api').Genre} -->
-  <ApiSelect v-model="selectedGenreIds" endpoint="/api/genres" id-prop="genreId" />
+  <ApiSelect v-model="genreIds" endpoint="/api/genres" id-prop="genreId" />
 </template>
 ```
 


### PR DESCRIPTION
resolves #204
Cherry picked from https://github.com/vuejs/docs/commit/7adfb64cf35de348a4c86a6eaf0f95053fa63838